### PR TITLE
Recommend/install TurboVNC 3.0 beta1 and VGL 3.0

### DIFF
--- a/Dockerfile.rstudio
+++ b/Dockerfile.rstudio
@@ -85,9 +85,9 @@ RUN apt -y install \
     r-recommended \ 
     r-base-dev \
     r-cran-rgl \
- && wget https://s3.amazonaws.com/turbovnc-pr/dev/linux/turbovnc_2.2.80_amd64.deb \
- && wget https://s3.amazonaws.com/virtualgl-pr/dev/linux/virtualgl_2.6.80_amd64.deb \
- && wget https://s3.amazonaws.com/virtualgl-pr/dev/linux/virtualgl32_2.6.80_amd64.deb \
+ && wget https://sourceforge.net/projects/turbovnc/files/2.2.90%20%283.0%20beta1%29/turbovnc_2.2.90_amd64.deb \
+ && wget https://sourceforge.net/projects/virtualgl/files/3.0/virtualgl_3.0_amd64.deb \
+ && wget https://sourceforge.net/projects/virtualgl/files/3.0/virtualgl32_3.0_amd64.deb \
  && dpkg -i turbovnc*.deb virtualgl*.deb \
  && wget https://download1.rstudio.org/desktop/bionic/amd64/rstudio-1.3.1093-amd64.deb \
  && gdebi --non-interactive rstu*.deb \

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository enable you to launch a VM (a host) to deploy SlicerMorpCloud doc
 ## Prerequsites for host
 1. If this is a GPU node, latest Nvidia Linux drivers need to be installed
 2. install docker, nvidia-docker, create docker group (each user will be added to docker group).  
-3. TurboVNC prerelease from https://s3.amazonaws.com/turbovnc-pr/dev/linux/index.html 
-4. Install the latest VirtualGL dev/3.0 evolving pre-release build (https://virtualgl.org/DeveloperInfo/PreReleases) on the host, using the procedure described in the VirtualGL User's Guide.
+3. TurboVNC 3.0 beta1 or a later release from <https://sourceforge.net/projects/turbovnc/files>
+4. Install VirtualGL 3.0 or a later release (<https://sourceforge.net/projects/virtualgl/files>) on the host, using the procedure described in the VirtualGL User's Guide.
 5. sudo vglserver_config (Select Option 3.)
 
 Last two steps can be skipped on non-GPU hosts.


### PR DESCRIPTION
The TurboVNC 3.0 evolving and VirtualGL 3.0 evolving pre-release links
are no longer valid, since TurboVNC 3.0 is now in beta and VirtualGL 3.0
is now out of beta.

(NOTE: TurboVNC 3.0 will soon be released as well, so the Docker image
should be updated to use TurboVNC 3.0 once it is available.)